### PR TITLE
Add support for .hdf5 and .hd5 naming conventions

### DIFF
--- a/_h5ls.sh
+++ b/_h5ls.sh
@@ -8,20 +8,18 @@ _h5ls()
     opts="-h --help -d --data -r --recursive -S --simple"
 
     local TAIL_WD=$(( ${#COMP_WORDS[@]} - ${COMP_CWORD} - 1 ))
-    if [[ $TAIL_WD > 0 ]]
-    then
+    if [[ $TAIL_WD > 0 ]]; then
         local DO_OPTS=1
-    elif [[ ${cur} == -* && $TAIL_WD == 0 ]]
-    then
+    elif [[ ${cur} == -* && $TAIL_WD == 0 ]]; then
         local DO_OPTS=1
     fi
 
 
-    if [[ ${DO_OPTS} ]]
-    then
+    if [[ ${DO_OPTS} ]]; then
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
-        return 0
-    elif [[ $cur == *.h5/* && ! -d ${cur%.h5/*}.h5 ]] ; then
+    elif [[ $cur == *.h5/* && ! -d ${cur%.h5/*}.h5 ]] || \
+         [[ $cur == *.hdf5/* && ! -d ${cur%.hdf5/*}.hdf5 ]] || \
+         [[ $cur == *.hd5/* && ! -d ${cur%.hdf5/*}.hd5 ]]; then
         WORDS=""
         local cmd="h5ls ${cur%/*}/"
         for end in $(eval $cmd | awk '$2 == "Group" {print $1}' )
@@ -35,10 +33,9 @@ _h5ls()
 
         cmd="compgen -W \"${WORDS}\" -- $cur"
         COMPREPLY=( $(eval $cmd) )
-        return 0
     else
-        COMPREPLY=( $(compgen -o plusdirs -f -X "!*.h5*" -- ${cur}) )
-        return 0
+        COMPREPLY=( $(compgen -o plusdirs -f -X "!*.h*5" -- ${cur}) )
     fi
+    return 0
 }
 complete -o filenames -o nospace -F _h5ls h5ls


### PR DESCRIPTION
Resolves #3 

Tab complete for `h5ls` now recognizes `.h5`, `.hdf5`, and `.hd5` as valid naming conventions for `HDF5` files.

Also apply cosmetic changes to Bash syntax and simplify return structure.